### PR TITLE
mvn тест проходит

### DIFF
--- a/students-registry/tasks-service/pom.xml
+++ b/students-registry/tasks-service/pom.xml
@@ -65,6 +65,17 @@
             <groupId>boost.brain.course</groupId>
             <artifactId>common-types</artifactId>
         </dependency>
+
+        <!-- Embedded Postgres от yandex
+               Для тетсирования сервиса.
+               https://mvnrepository.com/artifact/ru.yandex.qatools.embed/postgresql-embedded -->
+        <dependency>
+            <groupId>ru.yandex.qatools.embed</groupId>
+            <artifactId>postgresql-embedded</artifactId>
+            <version>2.10</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/students-registry/tasks-service/src/main/java/boost/brain/course/tasks/configuration/FilterConfig.java
+++ b/students-registry/tasks-service/src/main/java/boost/brain/course/tasks/configuration/FilterConfig.java
@@ -7,8 +7,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile("default")
 public class FilterConfig {
 
     @Value("${auth-login-check-url}")

--- a/students-registry/tasks-service/src/test/java/boost/brain/course/tasks/EmbeddedPostgresInitializer.java
+++ b/students-registry/tasks-service/src/test/java/boost/brain/course/tasks/EmbeddedPostgresInitializer.java
@@ -1,0 +1,40 @@
+package boost.brain.course.tasks;
+
+
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.support.GenericApplicationContext;
+import ru.yandex.qatools.embed.postgresql.EmbeddedPostgres;
+
+import java.io.IOException;
+
+import static ru.yandex.qatools.embed.postgresql.distribution.Version.Main.V9_6;
+
+/***
+ * при создании нового контекста приложения запускает базу на случайном порту и в контекст передаем данные подключения.
+ * В качестве базы выбран embeddedPostgres от Yandex (смотри pom.xml)
+ */
+public class EmbeddedPostgresInitializer
+        implements ApplicationContextInitializer<GenericApplicationContext> {
+
+    @Override
+    public void initialize(GenericApplicationContext applicationContext) {
+        final EmbeddedPostgres postgres = new EmbeddedPostgres(V9_6);
+        try {
+            final String url = postgres.start();
+            TestPropertyValues values = TestPropertyValues.of(
+                    "spring.test.database.replace=none",
+                    "spring.datasource.url=" + url,
+                    "spring.datasource.driver-class-name=org.postgresql.Driver",
+                    "spring.jpa.hibernate.ddl-auto=create",
+                    "spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true");
+
+            values.applyTo(applicationContext);
+            applicationContext.registerBean(EmbeddedPostgres.class, () -> postgres,
+                    beanDefinition -> beanDefinition.setDestroyMethodName("stop"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/students-registry/tasks-service/src/test/java/boost/brain/course/tasks/EmbeddedPostgresTest.java
+++ b/students-registry/tasks-service/src/test/java/boost/brain/course/tasks/EmbeddedPostgresTest.java
@@ -1,0 +1,24 @@
+package boost.brain.course.tasks;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/***
+ * Собственная аннотация заменяющая
+ * * @ContextConfiguration(initializers = EmbeddedPostgresInitializer.class)
+ * любой тест, аннотированный @EmbeddedPostgrestTest запустит базу на случайном порту
+ * и со случайным именем, настроит Spring на подключение к этой базе и в конце теста остановит ее.
+ * А так же выберем актвный профиль- test
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ActiveProfiles("test")
+@ContextConfiguration(initializers = EmbeddedPostgresInitializer.class)
+@interface EmbeddedPostgresTest {
+}

--- a/students-registry/tasks-service/src/test/java/boost/brain/course/tasks/TaskControllerTest.java
+++ b/students-registry/tasks-service/src/test/java/boost/brain/course/tasks/TaskControllerTest.java
@@ -29,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@EmbeddedPostgresTest
 public class TaskControllerTest {
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
1. В pom.xml сервиса «task-service” добавил «встроенную» БД — postgres Embedded от Yandex. Что бы создать временную базу для тестирования.
2. Добавил класс EmbeddedPostgresInitializer , который при запуске тестирования поднимает БД postgres, и в конце тестирования останавливает.
3. Добавил Аннотацию EmbeddedPostgresTest , что бы любой тест, аннотированный @EmbeddedPostgrestTest запустил базу на случайном порту и со случайным именем, настроил Spring на подключение к этой базе и в конце теста остановил ее. А так же эта аннотация выбирает активный профиль для тестирования- test .
4. В TaskControllerTest добавлена аннотация @EmbeddedPostgrestTest (см. пункт 3.)
5. В \students-registry\tasks-service\.......\tasks\configuration\ FilterConfig.java добавил аннотацию @Profile("default") Что бы не мешался при тестировании.
Теперь mvn тест проходит! 
PS. Дальше займусь юнит тестами API сервисов, которые не сделаны. А потом утилиту для нагрузочного тестирования.  Всё в рамках этого Issue.