### PR TITLE
24.01.16.16

### DIFF
--- a/students-registry/tasks-service/src/main/java/boost/brain/course/tasks/configuration/FilterConfig.java
+++ b/students-registry/tasks-service/src/main/java/boost/brain/course/tasks/configuration/FilterConfig.java
@@ -25,7 +25,7 @@ public class FilterConfig {
     public FilterRegistrationBean<CheckSessionFilter> checkSessionFilter(){
         FilterRegistrationBean<CheckSessionFilter> registrationBean = new FilterRegistrationBean<>();
         registrationBean.setFilter(new CheckSessionFilter(getCheckHeaderSession()));
-        registrationBean.addUrlPatterns("/*");
+        registrationBean.addUrlPatterns("/api/*");
         registrationBean.setOrder(1);
         return registrationBean;
     }


### PR DESCRIPTION
…Добавил ("/api/*"); для корректного вызова swagger-ui . В предыдущеq версии фильтром прикрыты все адреса сервиса, в том числе, те которое использует swagger, в текущей закроет только api методы.