### PR TITLE
Добавил метод Patch в список разрешенных методов для фильтра в прокси.

### DIFF
--- a/students-registry/proxy/src/main/java/boost/brain/course/proxy/config/SimpleCORSFilter.java
+++ b/students-registry/proxy/src/main/java/boost/brain/course/proxy/config/SimpleCORSFilter.java
@@ -44,7 +44,7 @@ public class SimpleCORSFilter implements Filter {
         HttpServletRequest request = (HttpServletRequest) req;
         logger.info("WebConfig; "+request.getRequestURI());
         response.setHeader("Access-Control-Allow-Origin", "*");
-        response.setHeader("Access-Control-Allow-Methods", "POST, PUT, GET, OPTIONS, DELETE");
+        response.setHeader("Access-Control-Allow-Methods", "POST, PUT, GET, OPTIONS, DELETE, PATCH");
         response.setHeader("Access-Control-Allow-Headers", "Content-Type, Access-Control-Allow-Headers, Authorization, sessionId, X-Requested-With,observe");
         response.setHeader("Access-Control-Max-Age", "3600");
         response.setHeader("Access-Control-Allow-Credentials", "true");
@@ -62,7 +62,7 @@ public class SimpleCORSFilter implements Filter {
         } else {
             System.out.println("Pre-flight");
             response.setHeader("Access-Control-Allow-Origin", "*");
-            response.setHeader("Access-Control-Allow-Methods", "POST,GET,DELETE,PUT");
+            response.setHeader("Access-Control-Allow-Methods", "POST,GET,DELETE,PUT,PATCH");
             response.setHeader("Access-Control-Max-Age", "3600");
             response.setHeader("Access-Control-Allow-Headers", "Access-Control-Expose-Headers"+"Authorization, sessionId, content-type,"+
                     "access-control-request-headers,access-control-request-method,accept,origin,authorization,x-requested-with,responseType,observe");


### PR DESCRIPTION
Пока вспомнил быстро сделал.
У нас в Енд-поинтах сервисов есть API методы   @PatchMapping, а доступ к ним закрыт на уровне proxy.
Добавка позволяет обойти этот баг.